### PR TITLE
`eventData` parameter in `backend.triggerControlEvent` accepts null values

### DIFF
--- a/src/flutter/flet_webview/lib/src/webview_mobile_and_mac.dart
+++ b/src/flutter/flet_webview/lib/src/webview_mobile_and_mac.dart
@@ -41,8 +41,7 @@ class _WebviewMobileAndMacState extends State<WebviewMobileAndMac> {
         },
         onUrlChange: (UrlChange url) {
           debugPrint('WebViewControl URL changed: ${url.url}');
-          widget.backend.triggerControlEvent(
-              widget.control.id, "url_change", url.url ?? "");
+          widget.backend.triggerControlEvent(widget.control.id, "url_change", url.url);
         },
         onPageStarted: (String url) {
           debugPrint('WebViewControl page started loading: $url');


### PR DESCRIPTION
Dependent on: https://github.com/flet-dev/flet/pull/4800